### PR TITLE
Feat/issue 9 enable user config

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -57,8 +57,11 @@ fn main() {
         Some(("compile", _sub_matches)) => {
             cli::subcommands::compile::compile();
         }
-        Some(("check", _sub_matches)) => {
-            cli::subcommands::check::check();
+        Some(("check", sub_matches)) => {
+            let check_option = sub_matches
+                .get_one::<cli::subcommands::check::CheckOption>("Check Option")
+                .unwrap();
+            cli::subcommands::check::check(check_option.to_owned());
         }
         Some(("completions", sub_matches)) => {
             let shell = sub_matches.get_one::<Shell>("shell").unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use mlua::Lua;
 use qplug::assets::INFO_LUA;
 use qplug::cli;
 use qplug::config::{Config, UserConfig, UserEnv};
+use qplug::lua::api::load_api;
 use std::io::{self};
 
 fn create_lua_env() -> Lua {
@@ -16,6 +17,8 @@ fn main() {
     // std::env::set_var("RUST_BACKTRACE", "full");
 
     let lua_env = create_lua_env();
+
+    load_api(&lua_env);
 
     let user_config = UserConfig::new(&lua_env);
     let config = Config::from_user_config(&user_config);

--- a/src/modules/cli/mod.rs
+++ b/src/modules/cli/mod.rs
@@ -3,7 +3,7 @@ use clap::{
     Command,
 };
 use clap_complete::Shell;
-use subcommands::build::VersionType;
+use subcommands::{build::VersionType, check::CheckOption};
 
 pub mod subcommands;
 
@@ -82,7 +82,14 @@ pub fn cli() -> Command {
             Command::new("compile")
                 .about("Complie the plugin. Do not increment versioning or copy to plugin folder."),
         )
-        .subcommand(Command::new("check").about("check if current directory is a valid plugin."))
+        .subcommand(Command::new("check")
+            .about("check if current directory is a valid plugin.")
+            .arg(Arg::new("Check Option")
+                .value_parser(value_parser!(CheckOption))
+                .ignore_case(true)
+                .default_value("qplug")
+            )
+        )
         //Generate shell completion
         .subcommand(
             Command::new("completions")

--- a/src/modules/cli/subcommands/build.rs
+++ b/src/modules/cli/subcommands/build.rs
@@ -5,7 +5,6 @@ use std::path::PathBuf;
 use crate::config::UserEnv;
 use crate::lua::info::PluginInfo;
 
-use super::compile::compile;
 use super::copy::copy_to_plugin_directory;
 
 //TODO: Refactor this to a more central location.
@@ -21,7 +20,7 @@ impl UserData for VersionType {}
 
 pub fn build(version: VersionType, info_path: PathBuf, user_env: UserEnv) {
     update_version(version, info_path, user_env.lua);
-    compile();
+    (user_env.config.build_tool)();
     copy_to_plugin_directory().expect("Could not copy plugin");
 }
 

--- a/src/modules/cli/subcommands/check.rs
+++ b/src/modules/cli/subcommands/check.rs
@@ -1,6 +1,6 @@
 use clap::ValueEnum;
 
-use crate::files::find_marker_file;
+use crate::{config::find_config_file, files::find_marker_file};
 
 #[derive(ValueEnum, Clone, Debug)]
 #[clap(rename_all = "lower")]
@@ -20,6 +20,9 @@ pub fn check(check_option: CheckOption) {
                 None => println!("Not a Qplug plugin. You may want to try `qplug init` or navigating to a qplug directory."),
             }
         }
-        CheckOption::Config => println!("Config file found!"),
+        CheckOption::Config => match find_config_file() {
+            Some(f) => println!("Config file found! {:?}", f),
+            None => println!("No config file found. You may want to try `qplug new`"),
+        },
     }
 }

--- a/src/modules/cli/subcommands/check.rs
+++ b/src/modules/cli/subcommands/check.rs
@@ -1,9 +1,25 @@
+use clap::ValueEnum;
+
 use crate::files::find_marker_file;
 
-pub fn check() {
-    let marker_file = find_marker_file(None);
-    match marker_file {
-        Some(f) => println!("Qplug plugin found! {:?}", f),
-        None => println!("Not a Qplug plugin. You may want to try `qplug init` or navigating to a qplug directory."),
+#[derive(ValueEnum, Clone, Debug)]
+#[clap(rename_all = "lower")]
+pub enum CheckOption {
+    Version,
+    Qplug,
+    Config,
+}
+
+pub fn check(check_option: CheckOption) {
+    match check_option {
+        CheckOption::Version => println!("Qplug version: {}", env!("CARGO_PKG_VERSION")),
+        CheckOption::Qplug => {
+            let marker_file = find_marker_file(None);
+            match marker_file {
+                Some(f) => println!("Qplug plugin found! {:?}", f),
+                None => println!("Not a Qplug plugin. You may want to try `qplug init` or navigating to a qplug directory."),
+            }
+        }
+        CheckOption::Config => println!("Config file found!"),
     }
 }

--- a/src/modules/cli/subcommands/check.rs
+++ b/src/modules/cli/subcommands/check.rs
@@ -1,6 +1,6 @@
 use clap::ValueEnum;
 
-use crate::{config::find_config_file, files::find_marker_file};
+use crate::{config::find_config_file, files::find_project_dir};
 
 #[derive(ValueEnum, Clone, Debug)]
 #[clap(rename_all = "lower")]
@@ -14,7 +14,7 @@ pub fn check(check_option: CheckOption) {
     match check_option {
         CheckOption::Version => println!("Qplug version: {}", env!("CARGO_PKG_VERSION")),
         CheckOption::Qplug => {
-            let marker_file = find_marker_file(None);
+            let marker_file = find_project_dir(None);
             match marker_file {
                 Some(f) => println!("Qplug plugin found! {:?}", f),
                 None => println!("Not a Qplug plugin. You may want to try `qplug init` or navigating to a qplug directory."),

--- a/src/modules/cli/subcommands/compile.rs
+++ b/src/modules/cli/subcommands/compile.rs
@@ -1,7 +1,7 @@
-use crate::{files::find_marker_file, lua::parser::merge_lua_files};
+use crate::{files::find_project_dir, lua::parser::merge_lua_files};
 
 pub fn compile() {
-    let marker = find_marker_file(None);
+    let marker = find_project_dir(None);
     if marker.is_some() {
         let root_path = marker.unwrap();
         let plugin_path = root_path.join("plugin_src");

--- a/src/modules/cli/subcommands/copy.rs
+++ b/src/modules/cli/subcommands/copy.rs
@@ -1,14 +1,14 @@
 #![allow(unused_imports)]
 use directories;
 
-use crate::files::find_marker_file;
+use crate::files::find_project_dir;
 
 #[cfg(windows)]
 pub fn copy_to_plugin_directory() -> Result<u64, std::io::Error> {
     let user_dir = directories::UserDirs::new().expect("Unable to locate user dir.");
     let docs = user_dir.document_dir().expect("Unable to locate docs dir.");
     let plugin_dir = docs.join("QSC").join("Q-Sys Designer").join("Plugins");
-    let marker_file = find_marker_file(None).expect("You might not be in a plugin directory.");
+    let marker_file = find_project_dir(None).expect("You might not be in a plugin directory.");
     let file_name = marker_file
         .file_name()
         .expect("Compiled qplug file not found. Please build or compile it first.")

--- a/src/modules/config.rs
+++ b/src/modules/config.rs
@@ -11,6 +11,8 @@ use std::{
 
 use crate::assets::TEMPLATE_DIR;
 
+use super::files::{find_project_dir, pwd, MARKER_FILE};
+
 pub struct UserEnv<'a> {
     pub lua: &'a Lua,
     pub config: &'a Config<'a, 'a>,

--- a/src/modules/files.rs
+++ b/src/modules/files.rs
@@ -89,7 +89,7 @@ pub fn create_marker_file(root_path: &Path) {
     fs::write(root_path.join(MARKER_FILE), "").expect("Failed to write marker file");
 }
 
-pub fn find_marker_file(path: Option<&Path>) -> Option<PathBuf> {
+pub fn find_project_dir(path: Option<&Path>) -> Option<PathBuf> {
     let mut current_dir = match path {
         Some(path) => path.into(),
         None => pwd(),

--- a/src/modules/files.rs
+++ b/src/modules/files.rs
@@ -5,7 +5,7 @@ use std::{
 
 use super::config::Template;
 
-const MARKER_FILE: &str = ".qplug";
+pub const MARKER_FILE: &str = ".qplug";
 
 pub enum Entry {
     FileSystem(fs::DirEntry),
@@ -86,7 +86,7 @@ pub fn copy_dir(source: &Template, dest: &Path) -> Result<(), io::Error> {
 }
 
 pub fn create_marker_file(root_path: &Path) {
-    fs::write(root_path.join(MARKER_FILE), "").expect("Failed to write marker file");
+    fs::write(root_path.join(MARKER_FILE), "return {}").expect("Failed to write marker file");
 }
 
 pub fn find_project_dir(path: Option<&Path>) -> Option<PathBuf> {
@@ -238,7 +238,7 @@ mod tests {
         create_marker_file(root_path);
 
         // Find the marker file starting from the nested directory
-        let found_marker = find_marker_file(Some(root_path)).unwrap();
+        let found_marker = find_project_dir(Some(root_path)).unwrap();
 
         // Verify the correct directory was found
         assert_eq!(found_marker, root_path.to_path_buf());
@@ -254,7 +254,7 @@ mod tests {
         fs::create_dir(&nested_dir).unwrap();
 
         // Try to find the marker file starting from the nested directory
-        let found_marker = find_marker_file(None);
+        let found_marker = find_project_dir(None);
 
         // Verify that no marker file was found
         assert!(found_marker.is_none());

--- a/src/modules/lua/api.rs
+++ b/src/modules/lua/api.rs
@@ -1,0 +1,21 @@
+use mlua::{
+    Lua,
+    Value::{self},
+};
+
+use crate::files::find_project_dir;
+
+pub fn load_api(lua: &Lua) {
+    let local_find = lua.create_function(|_, _: Value| {
+        let binding = find_project_dir(None).unwrap();
+        let result: Option<&str> = binding.to_str();
+        match result {
+            Some(path) => Ok(path.to_owned()),
+            _ => panic!("Invalid path"),
+        }
+    });
+
+    lua.globals()
+        .set("find_project_dir", local_find.unwrap())
+        .unwrap();
+}

--- a/src/modules/lua/mod.rs
+++ b/src/modules/lua/mod.rs
@@ -1,2 +1,3 @@
+pub mod api;
 pub mod info;
 pub mod parser;


### PR DESCRIPTION
#9 Fixes build command to use user config when available

#8 Adds new command for users to check to ensure their configs are discovered (Also adds args for version and the original check qplug to check if current directory is a qplug project.)

#6 Adds ability for users to create project specific configs. 